### PR TITLE
Add up dependency to Makefile exec targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,16 @@ lock: ## Regenerate pinned requirements/*.txt from *.in
 init: ## Generate .env with random passwords
 	bash scripts/init-env.sh
 
-train: ## Run training script inside Jupyter container
+train: up ## Run training script inside Jupyter container
 	docker compose exec jupyter python src/train.py
 
-test: ## Run pytest inside Jupyter container
+test: up ## Run pytest inside Jupyter container
 	docker compose exec jupyter pytest src/tests/ -v
 
-dvc-push: ## Push DVC-tracked data to MinIO
+dvc-push: up ## Push DVC-tracked data to MinIO
 	docker compose exec jupyter dvc push
 
-dvc-pull: ## Pull DVC-tracked data from MinIO
+dvc-pull: up ## Pull DVC-tracked data from MinIO
 	docker compose exec jupyter dvc pull
 
 template-test: ## Test copier template generation


### PR DESCRIPTION
## Summary

- `make train`, `make test`, `make dvc-push`, `make dvc-pull` now automatically start the stack if it's not running
- Previously these targets failed with `service "jupyter" is not running` unless the user had manually run `make up` first
- `docker compose up --detach --build` is idempotent, so this is safe when services are already running

## Test plan

- [x] `make down && make train` — stack starts automatically, training runs
- [x] `make test` with stack already running — no unnecessary rebuild delay

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)