### PR TITLE
Remove redundant bare hostnames from MLflow --allowed-hosts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -146,7 +146,7 @@ services:
         --artifacts-destination s3://${MINIO_BUCKET}
         --host 0.0.0.0
         --port 5000
-        --allowed-hosts mlflow,mlflow:5000,localhost,localhost:5000,localhost:${MLFLOW_PORT:-5050}
+        --allowed-hosts mlflow:5000,localhost:5000,localhost:${MLFLOW_PORT:-5050}
     healthcheck:
       test: wget -qO- http://localhost:5000/ >/dev/null 2>&1 || exit 1
       interval: 5s


### PR DESCRIPTION
## Summary

- Remove bare `mlflow` and `localhost` entries from `--allowed-hosts` that never match real requests (port 5000 is non-standard, so clients always include it in the `Host` header)
- Keep only the three entries matching actual traffic: `mlflow:5000`, `localhost:5000`, `localhost:${MLFLOW_PORT:-5050}`

Closes #35

## Test plan

- [x] `make up` — verify MLflow UI is accessible at `localhost:5050`
- [x] Healthcheck passes (`docker compose ps` shows mlflow as healthy)
- [x] Jupyter can log to MLflow (`MLFLOW_TRACKING_URI: http://mlflow:5000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)